### PR TITLE
Change to work with EL8.  Centos 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ Requirements
 
 As there's no public repository available, you'll need to download Spectrum Scale (GPFS) packages from the IBM website. Visit https://www.ibm.com/support/fixcentral and search for 'IBM Spectrum Scale (Software defined storage)'.
 
+#####**IBM Spectrum Scale Developer Edition**
+If you don't have an subscription you can now download the IBM Spectrum Scale Developer Edition
+- This edition provides all the features of the IBM Spectrum Scale Data Management Edition but it is limited to 12 TB per cluster.
+- There is no support from IBM for IBM Spectrum Scale Developer Edition.  Additionally, use in a production environment is prohibited. 
+- The Developer Edition can be access via https://www.ibm.com/us-en/marketplace/scale-out-file-and-object-storage
+
+
 Local Spectrum Scale Repo
 -------
-To created a local repo on a web server:
+Example: Create a local repo on a web server:
 
 ```
 cd /your/webserver/folder

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
 
   galaxy_tags:
     - ibm
@@ -21,5 +22,4 @@ galaxy_info:
     - interface
     - gui
 
-dependencies:
-  - acch.spectrum_scale
+dependencies: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,4 +39,4 @@
   package:
     name: "{{ scale_install_all_rpms }}"
     state: present
-  when: ansible_pkg_mgr == 'yum'
+  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'

--- a/tasks/install_repository.yml
+++ b/tasks/install_repository.yml
@@ -13,7 +13,7 @@
     state: present
   notify: yum-clean-metadata
   when:
-    - ansible_pkg_mgr == 'yum'
+    - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
     - scale_install_zimon_repository_url != 'existing'
 
 #

--- a/tasks/ldap.yml
+++ b/tasks/ldap.yml
@@ -25,7 +25,7 @@
   ignore_errors: yes
   no_log: false
   when:
-    - scale_gui_ldap_secure.keystore is not defined
+    - scale_gui_ldap.securekeystore is not defined
     - " 'EFSSG0100I' in scale_gui_conf_lsldap.stdout "
 
 - name: LDAP | Secure LDAP Integrate GUI #TODO Not tested
@@ -37,7 +37,7 @@
   ignore_errors: yes
   #no_log: true
   when:
-    - scale_gui_ldap_secure.keystore is defined
+    - scale_gui_ldap.securekeystore is defined
     - " 'EFSSG0100I' in scale_gui_conf_lsldap.stdout "
 
 #

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -30,7 +30,7 @@
   register: scale_gui_conf_createadmin
   failed_when: " 'EFSSG1000I' not in scale_gui_conf_createadmin.stdout"
   ignore_errors: yes
-  #no_log: true
+  no_log: true
   when:
     - scale_gui_admin_user is defined
     - " ( scale_gui_admin_user ) not in scale_gui_conf_gui_user_check.stdout"
@@ -44,7 +44,7 @@
   register: scale_gui_conf_create_gui_user
   failed_when: " 'EFSSG1000I' not in scale_gui_conf_create_gui_user.stdout"
   ignore_errors: yes
-  #no_log: true
+  no_log: true
   when:
     - scale_gui_user_username is defined
     - " ( scale_gui_user_username ) not in scale_gui_conf_gui_user_check.stdout"


### PR DESCRIPTION
Tested on Centos 8.1 and Centos 7.6
Added DNF and YUM as package manager to work with EL8
Uncomment the no_log in users to no output password in the ansible play.
Change the scale_gui_ldap_secure to same variable under scale_gui_ldap.securekeystore
Updated Ansible Meta file
updated readme with information about Spectrum Developer Edition and how to create Scale Repo